### PR TITLE
Check dtype of input tensors is correct

### DIFF
--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -141,7 +141,7 @@ def estimate_quantiles(A: Tensor, out: Tensor=None, offset: float=1/512) -> Tens
         raise NotImplementError(f'Not supported data type {A.dtype}')
     return out
 
-def quantize_blockwise(A: Tensor, code: Tensor=None, absmax: Tensor=None, rand=None, out: Tensor=None) -> Tensor:
+def quantize_blockwise(A: Tensor, code: Tensor=None, absmax: Tensor=None, rand=None, out: Tensor=None) -> Tuple[Tensor, Tuple[Tensor, Tensor]]:
     '''
     Quantize tensor A in blocks of size 4096 values.
 

--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -138,7 +138,7 @@ def estimate_quantiles(A: Tensor, out: Tensor=None, offset: float=1/512) -> Tens
     elif A.dtype == torch.float16:
         lib.cestimate_quantiles_fp16(get_ptr(A), get_ptr(out), ct.c_float(offset), ct.c_int(A.numel()))
     else:
-        raise NotImplementError(f'Not supported data type {A.dtype}')
+        raise ValueError(f'Unsupported data type {A.dtype}')
     return out
 
 def quantize_blockwise(A: Tensor, code: Tensor=None, absmax: Tensor=None, rand=None, out: Tensor=None) -> Tuple[Tensor, Tuple[Tensor, Tensor]]:

--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -205,7 +205,10 @@ def quantize_blockwise(A: Tensor, code: Tensor=None, absmax: Tensor=None, rand=N
     else:
         # cpu
         assert rand is None
-        lib.cquantize_blockwise_cpu_fp32(get_ptr(code), get_ptr(A), get_ptr(absmax), get_ptr(out), ct.c_int(A.numel()))
+        if A.dtype == torch.float32:
+            lib.cquantize_blockwise_cpu_fp32(get_ptr(code), get_ptr(A), get_ptr(absmax), get_ptr(out), ct.c_int(A.numel()))
+        else:
+            raise ValueError(f'Blockwise quantization of CPU tensors only supports 32-bit floats, but got {A.dtype}')
 
     return out, (absmax, code)
 
@@ -225,9 +228,9 @@ def dequantize_blockwise(A: Tensor, quant_state: Tuple[Tensor, Tensor]=None,
     quant_state : tuple(torch.Tensor, torch.Tensor)
         Tuple of code and absmax values. 
     absmax : torch.Tensor
-        The absmax values.
+        The absmax values as a float32 tensor.
     code : torch.Tensor
-        The quantization map.
+        The quantization map as a float32 tensor.
     out : torch.Tensor
         Dequantized output tensor (default: float32)
 
@@ -246,6 +249,10 @@ def dequantize_blockwise(A: Tensor, quant_state: Tuple[Tensor, Tensor]=None,
     if out is None: out = torch.zeros_like(A, dtype=torch.float32)
     if quant_state is None: quant_state = (absmax, code)
 
+    if quant_state[0].dtype != torch.float32:
+        raise ValueError(f'absmax should be a 32-bit float, but got {quant_state[0].dtype}')
+    if quant_state[1].dtype != torch.float32:
+        raise ValueError(f'code should be a 32-bit float, but got {quant_state[1].dtype}')
     if blocksize not in [2048, 4096]:
         raise ValueError(f'The blockwise of {blocksize} is not supported. Supported values: [2048 4096]')
 
@@ -257,7 +264,10 @@ def dequantize_blockwise(A: Tensor, quant_state: Tuple[Tensor, Tensor]=None,
         else:
             raise ValueError(f'Blockwise quantization only supports 16/32-bit floats, but got {A.dtype}')
     else:
-        lib.cdequantize_blockwise_cpu_fp32(get_ptr(quant_state[1]), get_ptr(A), get_ptr(quant_state[0]), get_ptr(out), ct.c_int(A.numel()))
+        if out.dtype == torch.float32:
+            lib.cdequantize_blockwise_cpu_fp32(get_ptr(quant_state[1]), get_ptr(A), get_ptr(quant_state[0]), get_ptr(out), ct.c_int(A.numel()))
+        else:
+            raise ValueError(f'Blockwise dequantization of CPU tensors only supports outputting 32-bit floats, but got {out.dtype}')
 
 
     return out


### PR DESCRIPTION
If a 16-bit float tensor on the CPU was passed as the input to quantize_blockwise or the output buffer for dequantize_blockwise, the code was previously passing its address to the `c[de]quantize_blockwise_cpu_fp32 method`, silently casting it to a 32-bit float* and resulting in segfaults.

A similar issue occurs if the absmax/code arguments to `dequantize_blockwise` are (somehow) 16-bit, resulting in illegal memory accesses on the GPU.

It took me a little while to track down the causes because of the cryptic errors; so I figured it was worth suggesting these changes. I've only been using the blockwise methods, so it's possible there are similar issues in other parts of the code - might be worth checking :)

This PR also includes a couple unrelated typo fixes.


Thanks for your work on this library, it's nice to squeeze the most I can out of my paltry GPU memory :)